### PR TITLE
Issue 542

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="lib" path="C:/Users/dmcco/Downloads/spigot-1.15.2.jar"/>
+	<classpathentry kind="lib" path="C:/Users/philb/Documents/spigot/spigot-1.15.2.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.project
+++ b/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>

--- a/src/main/java/factionsystem/Commands/HomeCommand.java
+++ b/src/main/java/factionsystem/Commands/HomeCommand.java
@@ -31,7 +31,7 @@ public class HomeCommand {
                     Chunk homeChunk = playersFaction.getFactionHome().getBlock().getChunk();
                     if (isClaimed(homeChunk, main.claimedChunks)){
                         // Ensure is in your faction
-                        ClaimedChunk claimedHomeChunk = getClaimedChunk(homeChunk.getX(), homeChunk.getZ(), main.claimedChunks);
+                        ClaimedChunk claimedHomeChunk = getClaimedChunk(homeChunk.getX(), homeChunk.getZ(), homeChunk.getWorld().getName(), main.claimedChunks);
                         if (claimedHomeChunk.getHolder() != null && !playersFaction.getName().equals(claimedHomeChunk.getHolder())) {
                             // Area is claimed by someone else and cannot be home. Cancel teleport and return;
                             player.sendMessage(ChatColor.RED + "Home was claimed by another faction, and has been lost.");

--- a/src/main/java/factionsystem/Commands/SetHomeCommand.java
+++ b/src/main/java/factionsystem/Commands/SetHomeCommand.java
@@ -25,7 +25,7 @@ public class SetHomeCommand {
                 if (playersFaction.isOwner(player.getUniqueId()) || playersFaction.isOfficer(player.getUniqueId())) {
 
                     if (isClaimed(player.getLocation().getChunk(), main.claimedChunks)) {
-                        ClaimedChunk chunk = getClaimedChunk(player.getLocation().getChunk().getX(), player.getLocation().getChunk().getZ(), main.claimedChunks);
+                        ClaimedChunk chunk = getClaimedChunk(player.getLocation().getChunk().getX(), player.getLocation().getChunk().getZ(), player.getLocation().getWorld().getName(), main.claimedChunks);
                         if (chunk.getHolder().equalsIgnoreCase(playersFaction.getName())) {
                             playersFaction.setFactionHome(player.getLocation());
                             player.sendMessage(ChatColor.GREEN + "Faction home set!");

--- a/src/main/java/factionsystem/EventHandlers/BlockBreakEventHandler.java
+++ b/src/main/java/factionsystem/EventHandlers/BlockBreakEventHandler.java
@@ -24,7 +24,7 @@ public class BlockBreakEventHandler {
         Player player = event.getPlayer();
 
         // get chunk
-        ClaimedChunk chunk = getClaimedChunk(event.getBlock().getLocation().getChunk().getX(), event.getBlock().getLocation().getChunk().getZ(), main.claimedChunks);
+        ClaimedChunk chunk = getClaimedChunk(event.getBlock().getLocation().getChunk().getX(), event.getBlock().getLocation().getChunk().getZ(), event.getBlock().getWorld().getName(), main.claimedChunks);
 
         // if chunk is claimed
         if (chunk != null) {

--- a/src/main/java/factionsystem/EventHandlers/BlockPlaceEventHandler.java
+++ b/src/main/java/factionsystem/EventHandlers/BlockPlaceEventHandler.java
@@ -25,7 +25,8 @@ public class BlockPlaceEventHandler {
         Player player = event.getPlayer();
 
         // get chunk
-        ClaimedChunk chunk = getClaimedChunk(event.getBlock().getLocation().getChunk().getX(), event.getBlock().getLocation().getChunk().getZ(), main.claimedChunks);
+        ClaimedChunk chunk = getClaimedChunk(event.getBlock().getLocation().getChunk().getX(), event.getBlock().getLocation().getChunk().getZ(),
+        		event.getBlock().getLocation().getWorld().getName(), main.claimedChunks);
 
         // if chunk is claimed
         if (chunk != null) {

--- a/src/main/java/factionsystem/EventHandlers/EntitySpawnEventHandler.java
+++ b/src/main/java/factionsystem/EventHandlers/EntitySpawnEventHandler.java
@@ -25,13 +25,11 @@ public class EntitySpawnEventHandler {
         z = event.getEntity().getLocation().getChunk().getZ();
 
         // check if land is claimed
-        for (ClaimedChunk chunk : main.claimedChunks) {
-            if (x == chunk.getCoordinates()[0] && z == chunk.getCoordinates()[1]) {
-
-                if (event.getEntity() instanceof Monster && !main.getConfig().getBoolean("mobsSpawnInFactionTerritory")) {
-                    event.setCancelled(true);
-                }
-
+        ClaimedChunk chunk = isChunkClaimed(x, y], event.getLocation().getWorld().getName());
+        if (chunk != null)
+        {
+            if (event.getEntity() instanceof Monster && !main.getConfig().getBoolean("mobsSpawnInFactionTerritory")) {
+                event.setCancelled(true);
             }
         }
     }

--- a/src/main/java/factionsystem/EventHandlers/EntitySpawnEventHandler.java
+++ b/src/main/java/factionsystem/EventHandlers/EntitySpawnEventHandler.java
@@ -1,6 +1,7 @@
 package factionsystem.EventHandlers;
 
 import factionsystem.Main;
+import factionsystem.Subsystems.UtilitySubsystem;
 import factionsystem.Objects.ClaimedChunk;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Monster;
@@ -25,8 +26,7 @@ public class EntitySpawnEventHandler {
         z = event.getEntity().getLocation().getChunk().getZ();
 
         // check if land is claimed
-        ClaimedChunk chunk = isChunkClaimed(x, y], event.getLocation().getWorld().getName());
-        if (chunk != null)
+        if (UtilitySubsystem.isClaimed(event.getLocation().getChunk(), main.claimedChunks))
         {
             if (event.getEntity() instanceof Monster && !main.getConfig().getBoolean("mobsSpawnInFactionTerritory")) {
                 event.setCancelled(true);

--- a/src/main/java/factionsystem/EventHandlers/PlayerDeathEventHandler.java
+++ b/src/main/java/factionsystem/EventHandlers/PlayerDeathEventHandler.java
@@ -53,9 +53,10 @@ public class PlayerDeathEventHandler {
             playerCoords[1] = player.getLocation().getChunk().getZ();
 
             // check if land is claimed
-            ClaimedChunk chunk = isChunkClaimed(playerCoords[0], playerCoords[1], player.getLocation().getWorld().getName());
-            if (chunk != null)
+            if (UtilitySubsystem.isClaimed(player.getLocation().getChunk(), main.claimedChunks))
             {
+            	ClaimedChunk chunk = UtilitySubsystem.getClaimedChunk(player.getLocation().getChunk().getX(), player.getLocation().getChunk().getZ(),
+            			player.getLocation().getWorld().getName(), main.claimedChunks);
                 // if holder is player's faction
                 if (chunk.getHolder().equalsIgnoreCase(getPlayersFaction(player.getUniqueId(), main.factions).getName()) && getPlayersFaction(player.getUniqueId(), main.factions).getAutoClaimStatus() == false) {
 

--- a/src/main/java/factionsystem/EventHandlers/PlayerDeathEventHandler.java
+++ b/src/main/java/factionsystem/EventHandlers/PlayerDeathEventHandler.java
@@ -53,21 +53,20 @@ public class PlayerDeathEventHandler {
             playerCoords[1] = player.getLocation().getChunk().getZ();
 
             // check if land is claimed
-            for (ClaimedChunk chunk : main.claimedChunks) {
-                if (playerCoords[0] == chunk.getCoordinates()[0] && playerCoords[1] == chunk.getCoordinates()[1]) {
+            ClaimedChunk chunk = isChunkClaimed(playerCoords[0], playerCoords[1], player.getLocation().getWorld().getName());
+            if (chunk != null)
+            {
+                // if holder is player's faction
+                if (chunk.getHolder().equalsIgnoreCase(getPlayersFaction(player.getUniqueId(), main.factions).getName()) && getPlayersFaction(player.getUniqueId(), main.factions).getAutoClaimStatus() == false) {
 
-                    // if holder is player's faction
-                    if (chunk.getHolder().equalsIgnoreCase(getPlayersFaction(player.getUniqueId(), main.factions).getName()) && getPlayersFaction(player.getUniqueId(), main.factions).getAutoClaimStatus() == false) {
+                    // if not killed by another player
+                    if (!(player.getKiller() instanceof Player)) {
 
-                        // if not killed by another player
-                        if (!(player.getKiller() instanceof Player)) {
-
-                            // player keeps items
-                            // event.setKeepInventory(true); // TODO: fix this duplicating items
-
-                        }
+                        // player keeps items
+                        // event.setKeepInventory(true); // TODO: fix this duplicating items
 
                     }
+
                 }
             }
 

--- a/src/main/java/factionsystem/EventHandlers/PlayerInteractEventHandler.java
+++ b/src/main/java/factionsystem/EventHandlers/PlayerInteractEventHandler.java
@@ -51,7 +51,7 @@ public class PlayerInteractEventHandler {
             // ---------------------------------------------------------------------------------------------------------------
 
             // if chunk is claimed
-            ClaimedChunk chunk = getClaimedChunk(event.getClickedBlock().getLocation().getChunk().getX(), event.getClickedBlock().getLocation().getChunk().getZ(), main.claimedChunks);
+            ClaimedChunk chunk = getClaimedChunk(event.getClickedBlock().getLocation().getChunk().getX(), event.getClickedBlock().getLocation().getChunk().getZ(), event.getClickedBlock().getLocation().getWorld().getName(), main.claimedChunks);
             if (chunk != null) {
                 handleClaimedChunk(event, chunk);
             }
@@ -99,7 +99,8 @@ public class PlayerInteractEventHandler {
 
     private void handleLockingBlock(PlayerInteractEvent event, Player player, Block clickedBlock) {
         // if chunk is claimed
-        ClaimedChunk chunk = getClaimedChunk(event.getClickedBlock().getLocation().getChunk().getX(), event.getClickedBlock().getLocation().getChunk().getZ(), main.claimedChunks);
+        ClaimedChunk chunk = getClaimedChunk(event.getClickedBlock().getLocation().getChunk().getX(), event.getClickedBlock().getLocation().getChunk().getZ(),
+        		event.getClickedBlock().getLocation().getWorld().getName(), main.claimedChunks);
         if (chunk != null) {
 
             // if claimed by other faction

--- a/src/main/java/factionsystem/EventHandlers/PlayerMoveEventHandler.java
+++ b/src/main/java/factionsystem/EventHandlers/PlayerMoveEventHandler.java
@@ -52,7 +52,7 @@ public class PlayerMoveEventHandler {
 
             // if new chunk is claimed and old chunk was not
             if (isClaimed(event.getTo().getChunk(), main.claimedChunks) && !isClaimed(event.getFrom().getChunk(), main.claimedChunks)) {
-                String title = getClaimedChunk(event.getTo().getChunk().getX(), event.getTo().getChunk().getZ(), main.claimedChunks).getHolder();
+                String title = getClaimedChunk(event.getTo().getChunk().getX(), event.getTo().getChunk().getZ(), event.getTo().getWorld().getName(), main.claimedChunks).getHolder();
                 event.getPlayer().sendTitle(title, null, 10, 70, 20);
                 return;
             }
@@ -66,8 +66,8 @@ public class PlayerMoveEventHandler {
             // if new chunk is claimed and old chunk was also claimed
             if (isClaimed(event.getTo().getChunk(), main.claimedChunks) && isClaimed(event.getFrom().getChunk(), main.claimedChunks)) {
                 // if chunk holders are not equal
-                if (!(getClaimedChunk(event.getFrom().getChunk().getX(), event.getFrom().getChunk().getZ(), main.claimedChunks).getHolder().equalsIgnoreCase(getClaimedChunk(event.getTo().getChunk().getX(), event.getTo().getChunk().getZ(), main.claimedChunks).getHolder()))) {
-                    String title = getClaimedChunk(event.getTo().getChunk().getX(), event.getTo().getChunk().getZ(), main.claimedChunks).getHolder();
+                if (!(getClaimedChunk(event.getFrom().getChunk().getX(), event.getFrom().getChunk().getZ(), event.getFrom().getWorld().getName(), main.claimedChunks).getHolder().equalsIgnoreCase(getClaimedChunk(event.getTo().getChunk().getX(), event.getTo().getChunk().getZ(), event.getTo().getWorld().getName(), main.claimedChunks).getHolder()))) {
+                    String title = getClaimedChunk(event.getTo().getChunk().getX(), event.getTo().getChunk().getZ(), event.getTo().getWorld().getName(), main.claimedChunks).getHolder();
                     event.getPlayer().sendTitle(title, null, 10, 70, 20);
                 }
             }

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -27,7 +27,7 @@ public class UtilitySubsystem {
 
     // non-static methods
     
-    public ClaimedChunk isChunkClaimed(double x, double y, string world)
+    public ClaimedChunk isChunkClaimed(double x, double y, String world)
     {
     	for (ClaimedChunk chunk : main.claimedChunks)
     	{
@@ -488,14 +488,15 @@ public class UtilitySubsystem {
         }
 
     }
-
+    
     public static boolean isClaimed(Chunk chunk, ArrayList<ClaimedChunk> claimedChunks) {
 
-    	ClaimedChunk chunk = isChunkClaimed(chunk.getX(), chunk.getY(), chunk.getWorld());
-    	if (chunk != null)
-    	{
-    		return true;
-    	}
+        for (ClaimedChunk claimedChunk : claimedChunks) {
+            if (claimedChunk.getCoordinates()[0] == chunk.getX() && claimedChunk.getCoordinates()[1] == chunk.getZ()
+            		&& claimedChunk.getWorld() == chunk.getWorld().getName()) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -26,6 +26,19 @@ public class UtilitySubsystem {
     }
 
     // non-static methods
+    
+    public ClaimedChunk isChunkClaimed(double x, double y, string world)
+    {
+    	for (ClaimedChunk chunk : main.claimedChunks)
+    	{
+    		if (x == chunk.getCoordinates()[0] && y == chunk.getCoordinates()[1] && world == chunk.getWorld())
+    		{
+    			return chunk;
+    		}
+    	}
+    	
+    	return null;
+    }
 
     public void addChunkAtPlayerLocation(Player player) {
         double[] playerCoords = new double[2];
@@ -35,7 +48,9 @@ public class UtilitySubsystem {
             if (faction.isOwner(player.getUniqueId()) || faction.isOfficer(player.getUniqueId())) {
 
                 // check if land is already claimed
-                for (ClaimedChunk chunk : main.claimedChunks) {
+                ClaimedChunk chunk = isChunkClaimed(playerCoords[0], playerCoords[1], player.getLocation().getWorld().getName());
+                if (chunk != null)
+        		{
                     if (playerCoords[0] == chunk.getCoordinates()[0] && playerCoords[1] == chunk.getCoordinates()[1]) {
 
                         // if holder is player's faction
@@ -108,12 +123,12 @@ public class UtilitySubsystem {
         playerCoords[1] = player.getLocation().getChunk().getZ();
 
         if (main.adminsBypassingProtections.contains(player.getUniqueId())) {
-            for (ClaimedChunk chunk : main.claimedChunks) {
-                if (playerCoords[0] == chunk.getCoordinates()[0] && playerCoords[1] == chunk.getCoordinates()[1]) {
-                    removeChunk(chunk, player, getFaction(chunk.getHolder(), main.factions));
-                    player.sendMessage(ChatColor.GREEN + "Land unclaimed using admin bypass!");
-                    return;
-                }
+        	ClaimedChunk chunk = isChunkClaimed(playerCoords[0], playerCoords[1], player.getLocation().getWorld().getName());
+            if (chunk != null)
+            {
+                removeChunk(chunk, player, getFaction(chunk.getHolder(), main.factions));
+                player.sendMessage(ChatColor.GREEN + "Land unclaimed using admin bypass!");
+                return;
             }
             player.sendMessage(ChatColor.RED + "This land is not currently claimed!");
             return;
@@ -121,21 +136,20 @@ public class UtilitySubsystem {
 
         for (Faction faction : main.factions) {
             if (faction.isOwner(player.getUniqueId()) || faction.isOfficer(player.getUniqueId())) {
-
                 // check if land is claimed by player's faction
-                for (ClaimedChunk chunk : main.claimedChunks) {
-                    if (playerCoords[0] == chunk.getCoordinates()[0] && playerCoords[1] == chunk.getCoordinates()[1]) {
-                        // if holder is player's faction
-                        if (chunk.getHolder().equalsIgnoreCase(faction.getName())) {
-                            removeChunk(chunk, player, faction);
-                            player.sendMessage(ChatColor.GREEN + "Land unclaimed.");
+            	ClaimedChunk chunk = isChunkClaimed(playerCoords[0], playerCoords[1], player.getLocation().getWorld().getName());
+            	if (chunk != null)
+            	{
+                    // if holder is player's faction
+                    if (chunk.getHolder().equalsIgnoreCase(faction.getName())) {
+                        removeChunk(chunk, player, faction);
+                        player.sendMessage(ChatColor.GREEN + "Land unclaimed.");
 
-                            return;
-                        }
-                        else {
-                            player.sendMessage(ChatColor.RED + "This land is claimed by " + chunk.getHolder());
-                            return;
-                        }
+                        return;
+                    }
+                    else {
+                        player.sendMessage(ChatColor.RED + "This land is claimed by " + chunk.getHolder());
+                        return;
                     }
                 }
 
@@ -149,8 +163,8 @@ public class UtilitySubsystem {
         // if faction home is located on this chunk
         Location factionHome = getPlayersFaction(player.getUniqueId(), main.factions).getFactionHome();
         if (factionHome != null) {
-            if (factionHome.getChunk().getX() == chunk.getChunk().getX() && factionHome.getChunk().getZ() == chunk.getChunk().getZ()) {
-
+            if (factionHome.getChunk().getX() == chunk.getChunk().getX() && factionHome.getChunk().getZ() == chunk.getChunk().getZ()
+            		&& chunk.getWorld() == player.getLocation().getWorld().getName()) {
                 // remove faction home
                 faction.setFactionHome(null);
                 sendAllPlayersInFactionMessage(faction, ChatColor.RED + "Your faction home has been removed!");
@@ -175,11 +189,10 @@ public class UtilitySubsystem {
         double[] playerCoords = new double[2];
         playerCoords[0] = player.getLocation().getChunk().getX();
         playerCoords[1] = player.getLocation().getChunk().getZ();
-        for (ClaimedChunk chunk : main.claimedChunks) {
-            if (playerCoords[0] == chunk.getCoordinates()[0] && playerCoords[1] == chunk.getCoordinates()[1]
-                    && player.getWorld().getName().equals(chunk.getWorld())) {
-                return chunk.getHolder();
-            }
+        ClaimedChunk chunk = isChunkClaimed(playerCoords[0], playerCoords[1], player.getLocation().getWorld().getName());
+        if (chunk != null)
+        {
+            return chunk.getHolder();
         }
         return "unclaimed";
     }
@@ -477,17 +490,18 @@ public class UtilitySubsystem {
     }
 
     public static boolean isClaimed(Chunk chunk, ArrayList<ClaimedChunk> claimedChunks) {
-        for (ClaimedChunk claimedChunk : claimedChunks) {
-            if (claimedChunk.getCoordinates()[0] == chunk.getX() && claimedChunk.getCoordinates()[1] == chunk.getZ()) {
-                return true;
-            }
-        }
+
+    	ClaimedChunk chunk = isChunkClaimed(chunk.getX(), chunk.getY(), chunk.getWorld());
+    	if (chunk != null)
+    	{
+    		return true;
+    	}
         return false;
     }
 
-    public static ClaimedChunk getClaimedChunk(int x, int z, ArrayList<ClaimedChunk> claimedChunks) {
+    public static ClaimedChunk getClaimedChunk(int x, int z, String world, ArrayList<ClaimedChunk> claimedChunks) {
         for (ClaimedChunk claimedChunk : claimedChunks) {
-            if (claimedChunk.getCoordinates()[0] == x && claimedChunk.getCoordinates()[1] == z) {
+            if (claimedChunk.getCoordinates()[0] == x && claimedChunk.getCoordinates()[1] == z && claimedChunk.getWorld() == world) {
                 return claimedChunk;
             }
         }


### PR DESCRIPTION
I believe this last commit will resolve the issues with claims bleeding over into the nether.  I tested this on my local and the MovePlayerEvent implementation now works as expected: you can make a claim in the overworld, then TP to that same chunk in the nether and the wildernsess/claim name message will no longer pop up.