### PR TITLE
Issue #565 - Delete Old Config Options + Config Subsystem Addition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>KingdomProgrammers</groupId>
     <artifactId>Medieval-Factions</artifactId>
-    <version>v3.4.3</version>
+    <version>v3.4.4</version>
     <packaging>jar</packaging>
 
     <name>Medieval Factions</name>

--- a/src/main/java/factionsystem/Commands/ConfigCommand.java
+++ b/src/main/java/factionsystem/Commands/ConfigCommand.java
@@ -29,7 +29,7 @@ public class ConfigCommand {
                         player.sendMessage(ChatColor.AQUA + "version: " + main.getConfig().getString("version")
                                 + ", initialMaxPowerLevel: " + main.getConfig().getInt("initialMaxPowerLevel")
                                 + ", initialPowerLevel: " +  main.getConfig().getInt("initialPowerLevel")
-                                + ", hourlyPowerIncreaseAmount: " + main.getConfig().getInt("hourlyPowerIncreaseAmount")
+                                + ", powerIncreaseAmount: " + main.getConfig().getInt("powerIncreaseAmount")
                                 + ", mobsSpawnInFactionTerritory: " + main.getConfig().getBoolean("mobsSpawnInFactionTerritory")
                                 + ", laddersPlaceableInEnemyFactionTerritory: " + main.getConfig().getBoolean("laddersPlaceableInEnemyFactionTerritory")
                                 + ", minutesBeforeInitialPowerIncrease: " + main.getConfig().getInt("minutesBeforeInitialPowerIncrease")
@@ -84,7 +84,7 @@ public class ConfigCommand {
                 return;
             }
             else if (option.equalsIgnoreCase("initialMaxPowerLevel") || option.equalsIgnoreCase("initialPowerLevel")
-                    || option.equalsIgnoreCase("hourlyPowerIncreaseAmount")
+                    || option.equalsIgnoreCase("powerIncreaseAmount")
                     || option.equalsIgnoreCase("minutesBeforeInitialPowerIncrease")
                     || option.equalsIgnoreCase("minutesBetweenPowerIncreases")
                     || option.equalsIgnoreCase("officerLimit")

--- a/src/main/java/factionsystem/Commands/ConfigCommand.java
+++ b/src/main/java/factionsystem/Commands/ConfigCommand.java
@@ -27,7 +27,7 @@ public class ConfigCommand {
 
                         // no further arguments needed, list config
                         player.sendMessage(ChatColor.AQUA + "version: " + main.getConfig().getString("version")
-                                + ", maxPowerLevel: " + main.getConfig().getInt("maxPowerLevel")
+                                + ", initialMaxPowerLevel: " + main.getConfig().getInt("initialMaxPowerLevel")
                                 + ", initialPowerLevel: " +  main.getConfig().getInt("initialPowerLevel")
                                 + ", hourlyPowerIncreaseAmount: " + main.getConfig().getInt("hourlyPowerIncreaseAmount")
                                 + ", mobsSpawnInFactionTerritory: " + main.getConfig().getBoolean("mobsSpawnInFactionTerritory")
@@ -83,7 +83,7 @@ public class ConfigCommand {
                 player.sendMessage(ChatColor.RED + "Can't set version!");
                 return;
             }
-            else if (option.equalsIgnoreCase("maxPowerLevel") || option.equalsIgnoreCase("initialPowerLevel")
+            else if (option.equalsIgnoreCase("initialMaxPowerLevel") || option.equalsIgnoreCase("initialPowerLevel")
                     || option.equalsIgnoreCase("hourlyPowerIncreaseAmount")
                     || option.equalsIgnoreCase("minutesBeforeInitialPowerIncrease")
                     || option.equalsIgnoreCase("minutesBetweenPowerIncreases")

--- a/src/main/java/factionsystem/Commands/CreateCommand.java
+++ b/src/main/java/factionsystem/Commands/CreateCommand.java
@@ -48,7 +48,7 @@ public class CreateCommand {
                 if (!factionExists) {
 
                     // actual faction creation
-                    Faction temp = new Faction(name, player.getUniqueId(), main.getConfig().getInt("maxPowerLevel"), main);
+                    Faction temp = new Faction(name, player.getUniqueId(), main.getConfig().getInt("initialMaxPowerLevel"), main);
                     main.factions.add(temp);
                     // TODO: Make thread safe
                     main.factions.get(main.factions.size() - 1).addMember(player.getUniqueId(), getPlayersPowerRecord(player.getUniqueId(), main.playerPowerRecords).getPowerLevel());

--- a/src/main/java/factionsystem/Main.java
+++ b/src/main/java/factionsystem/Main.java
@@ -33,7 +33,7 @@ import java.util.UUID;
 public class Main extends JavaPlugin implements Listener {
 
     // version
-    public static String version = "v3.4.3";
+    public static String version = "v3.4.4";
 
     // subsystems
     public StorageSubsystem storage = new StorageSubsystem(this);

--- a/src/main/java/factionsystem/Main.java
+++ b/src/main/java/factionsystem/Main.java
@@ -6,6 +6,7 @@ import factionsystem.Objects.Faction;
 import factionsystem.Objects.LockedBlock;
 import factionsystem.Objects.PlayerPowerRecord;
 import factionsystem.Subsystems.CommandSubsystem;
+import factionsystem.Subsystems.ConfigSubsystem;
 import factionsystem.Subsystems.StorageSubsystem;
 import factionsystem.Subsystems.UtilitySubsystem;
 import factionsystem.Util.Pair;
@@ -37,6 +38,7 @@ public class Main extends JavaPlugin implements Listener {
     // subsystems
     public StorageSubsystem storage = new StorageSubsystem(this);
     public UtilitySubsystem utilities = new UtilitySubsystem(this);
+    public ConfigSubsystem config = new ConfigSubsystem(this);
 
     // saved lists
     public ArrayList<Faction> factions = new ArrayList<>();
@@ -65,12 +67,12 @@ public class Main extends JavaPlugin implements Listener {
 
         // config creation/loading
         if (!(new File("./plugins/MedievalFactions/config.yml").exists())) {
-            utilities.saveConfigDefaults();
+            config.saveConfigDefaults();
         }
         else {
             if (!getConfig().getString("version").equalsIgnoreCase(Main.version)) {
                 System.out.println("[ALERT] Version mismatch! Adding missing defaults and setting version!");
-                utilities.handleVersionMismatch();
+                config.handleVersionMismatch();
             }
             reloadConfig();
         }

--- a/src/main/java/factionsystem/Objects/PlayerPowerRecord.java
+++ b/src/main/java/factionsystem/Objects/PlayerPowerRecord.java
@@ -43,14 +43,14 @@ public class PlayerPowerRecord {
 
     public int maxPower() {
         if (UtilitySubsystem.isPlayerAFactionOwner(playerUUID, main.factions)){
-            return (int) (main.getConfig().getDouble("maxPowerLevel") * main.getConfig().getDouble("factionOwnerMultiplier", 2.0));
+            return (int) (main.getConfig().getDouble("initialMaxPowerLevel") * main.getConfig().getDouble("factionOwnerMultiplier", 2.0));
         }
 
         if (UtilitySubsystem.isPlayerAFactionOfficer(playerUUID, main.factions)){
-            return (int) (main.getConfig().getDouble("maxPowerLevel") * main.getConfig().getDouble("factionOfficerMultiplier", 1.5));
+            return (int) (main.getConfig().getDouble("initialMaxPowerLevel") * main.getConfig().getDouble("factionOfficerMultiplier", 1.5));
         }
 
-        return main.getConfig().getInt("maxPowerLevel");
+        return main.getConfig().getInt("initialMaxPowerLevel");
     }
 
 

--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -1,0 +1,101 @@
+package factionsystem.Subsystems;
+
+import factionsystem.Main;
+
+public class ConfigSubsystem {
+
+    Main main = null;
+
+    public ConfigSubsystem(Main plugin) {
+        main = plugin;
+    }
+
+    public void handleVersionMismatch() {
+        // set version
+        if (!main.getConfig().isString("version")) {
+            System.out.println("Version not set! Setting version to " + main.version);
+            main.getConfig().addDefault("version", main.version);
+        }
+        else {
+            System.out.println("Version set but mismatched! Setting version to " + main.version);
+            main.getConfig().set("version", main.version);
+        }
+
+        // add defaults if they don't exist
+        if (!main.getConfig().isInt("maxPowerLevel")) {
+            System.out.println("Max power level not set! Setting to default!");
+            main.getConfig().addDefault("maxPowerLevel", 20);
+        }
+        if (!main.getConfig().isInt("initialPowerLevel")) {
+            System.out.println("Initial power level not set! Setting to default!");
+            main.getConfig().addDefault("initialPowerLevel", 5);
+        }
+        if (!main.getConfig().isBoolean("mobsSpawnInFactionTerritory")) {
+            System.out.println("Mobs spawn in faction territory not set! Setting to default!");
+            main.getConfig().addDefault("mobsSpawnInFactionTerritory", false);
+        }
+        if (!main.getConfig().isInt("hourlyPowerIncreaseAmount")) {
+            System.out.println("Hourly power increase amount not set! Setting to default!");
+            main.getConfig().addDefault("hourlyPowerIncreaseAmount", 2);
+        }
+        if (!main.getConfig().isBoolean("laddersPlaceableInEnemyFactionTerritory")) {
+            System.out.println("Ladders placeable in enemy faction territory not set! Setting to default!");
+            main.getConfig().addDefault("laddersPlaceableInEnemyFactionTerritory", true);
+        }
+        if (!main.getConfig().isInt("minutesBeforeInitialPowerIncrease")) {
+            System.out.println("minutesBeforeInitialPowerIncrease not set! Setting to default!");
+            main.getConfig().addDefault("minutesBeforeInitialPowerIncrease", 30);
+        }
+        if (!main.getConfig().isInt("minutesBetweenPowerIncreases")) {
+            System.out.println("minutesBetweenPowerIncreases not set! Setting to default!");
+            main.getConfig().addDefault("minutesBetweenPowerIncreases", 60);
+        }
+
+        if (!main.getConfig().isBoolean("warsRequiredForPVP")) {
+            System.out.println("warsRequiredForPVP not set! Setting to default!");
+            main.getConfig().addDefault("warsRequiredForPVP", true);
+        }
+
+        if (!main.getConfig().isBoolean("officerLimit")) {
+            System.out.println("officerLimit not set! Setting to default!");
+            main.getConfig().addDefault("officerLimit", 0);
+        }
+
+        if (!main.getConfig().isDouble("factionOwnerMultiplier")) {
+            System.out.println("factionOwnerMultiplier not set! Setting to default");
+            main.getConfig().addDefault("factionOwnerMultiplier", 2.0);
+        }
+
+        if (!main.getConfig().isDouble("officerPerMemberCount")){
+            System.out.println("officerPerMemberCount is not set! Setting to default");
+            main.getConfig().addDefault("officerPerMemberCount", 5);
+        }
+
+        if (!main.getConfig().isDouble("factionOfficerMultiplier")){
+            System.out.println("factionOfficerMultiplier is not set! Setting to default");
+            main.getConfig().addDefault("factionOfficerMultiplier", 2.0);
+        }
+
+        main.getConfig().options().copyDefaults(true);
+        main.saveConfig();
+    }
+
+    public void saveConfigDefaults() {
+        main.getConfig().addDefault("version", main.version);
+        main.getConfig().addDefault("maxPowerLevel", 20);
+        main.getConfig().addDefault("initialPowerLevel", 5);
+        main.getConfig().addDefault("hourlyPowerIncreaseAmount", 2);
+        main.getConfig().addDefault("mobsSpawnInFactionTerritory", false);
+        main.getConfig().addDefault("laddersPlaceableInEnemyFactionTerritory", true);
+        main.getConfig().addDefault("minutesBeforeInitialPowerIncrease", 30);
+        main.getConfig().addDefault("minutesBetweenPowerIncreases", 60);
+        main.getConfig().addDefault("warsRequiredForPVP", true);
+        main.getConfig().addDefault("officerLimit", 0);
+        main.getConfig().addDefault("factionOwnerMultiplier", 2.0);
+        main.getConfig().addDefault("officerPerMemberCount", 5);
+        main.getConfig().addDefault("factionOfficerMultiplier", 1.5);
+        main.getConfig().options().copyDefaults(true);
+        main.saveConfig();
+    }
+
+}

--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -92,29 +92,36 @@ public class ConfigSubsystem {
 
     private void deleteConfigOption(String option) {
         File configFile = new File("./plugins/MedievalFactions/config.yml");
-        File tempFile = new File("./plugins/MedievalFactions/temp-config.yml");
         System.out.println("Attempting to delete old config option: " + option);
         try {
-            Scanner scanner = new Scanner(configFile);
+            System.out.println("Creating temporary config file");
+            File tempFile = new File("./plugins/MedievalFactions/temp-config.yml");
+            Scanner loadReader = new Scanner(configFile);
             FileWriter writer = new FileWriter(tempFile);
-            String currentLine;
 
-            while(scanner.hasNextLine() && ((currentLine = scanner.nextLine()) != null)) {
-                if(!currentLine.contains(option)) {
-                    System.out.println("Found old config option: " + option + ". Writing to new file.");
-                    writer.write(currentLine + "\n");
+            // actual loading
+            while (loadReader.hasNextLine()) {
+                String next = loadReader.nextLine();
+                if (next.contains(option)) {
+                    System.out.println("Line contains the option! Doing nothing!");
+                    System.out.println("Line: '" + next + "'");
+                    System.out.println("----------------------------------------");
+                }
+                else {
+                    System.out.println("Line does not contain the option! Copying over to the temporary config file!");
+                    System.out.println("----------------------------------------");
+                    writer.write(next);
                 }
             }
+            System.out.println("No more lines found.");
+            System.out.println("----------------------------------------");
 
+            System.out.println("Deleting config.yml");
             configFile.delete();
-            File newFile = new File("./plugins/MedievalFactions/config.yml");
-            tempFile.renameTo(newFile);
 
-            writer.close();
-            scanner.close();
-        }
-        catch(Exception e) {
-            System.out.println("Something went wrong when deleting a config option.");
+            loadReader.close();
+        } catch (Exception e) {
+            System.out.println("There was a problem deleting the config option.");
             e.printStackTrace();
         }
     }

--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -90,9 +90,7 @@ public class ConfigSubsystem {
 
     private void deleteOldConfigOptionsIfPresent() {
         for (String option : oldConfigOptions) {
-            if (main.getConfig().isSet(option)) {
-                deleteConfigOption(option);
-            }
+            deleteConfigOption(option);
         }
     }
 

--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -126,7 +126,7 @@ public class ConfigSubsystem {
 
     public void saveConfigDefaults() {
         main.getConfig().addDefault("version", main.version);
-        main.getConfig().addDefault("maxPowerLevel", 20);
+        main.getConfig().addDefault("initialMaxPowerLevel", 20);
         main.getConfig().addDefault("initialPowerLevel", 5);
         main.getConfig().addDefault("powerIncreaseAmount", 2);
         main.getConfig().addDefault("mobsSpawnInFactionTerritory", false);
@@ -134,7 +134,6 @@ public class ConfigSubsystem {
         main.getConfig().addDefault("minutesBeforeInitialPowerIncrease", 30);
         main.getConfig().addDefault("minutesBetweenPowerIncreases", 60);
         main.getConfig().addDefault("warsRequiredForPVP", true);
-        main.getConfig().addDefault("officerLimit", 0);
         main.getConfig().addDefault("factionOwnerMultiplier", 2.0);
         main.getConfig().addDefault("officerPerMemberCount", 5);
         main.getConfig().addDefault("factionOfficerMultiplier", 1.5);

--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -11,8 +11,6 @@ public class ConfigSubsystem {
 
     Main main = null;
 
-    private final List<String> oldConfigOptions = Arrays.asList("officerLimit", "hourlyPowerIncreaseAmount", "maxPowerLevel");
-
     public ConfigSubsystem(Main plugin) {
         main = plugin;
     }
@@ -85,55 +83,19 @@ public class ConfigSubsystem {
     }
 
     private void deleteOldConfigOptionsIfPresent() {
-        for (String option : oldConfigOptions) {
-            deleteConfigOption(option);
+
+        if (main.getConfig().isInt("officerLimit")) {
+            main.getConfig().set("officerLimit", null);
         }
-    }
 
-    private void deleteConfigOption(String option) {
-        System.out.println("Attempting to delete old config option: " + option);
-        try {
-            System.out.println("Creating temporary config file");
-            File tempFile = new File("./plugins/MedievalFactions/temp-config.yml");
-            FileWriter writer = new FileWriter(tempFile);
-
-            File configFile = new File("./plugins/MedievalFactions/config.yml");
-            Scanner loadReader = new Scanner(configFile);
-
-            // actual loading
-            while (loadReader.hasNextLine()) {
-                String next = loadReader.nextLine();
-                if (next.contains(option)) {
-                    System.out.println("Line contains the option! Doing nothing!");
-                    System.out.println("Line: '" + next + "'");
-                    System.out.println("----------------------------------------");
-                }
-                else {
-                    System.out.println("Line does not contain the option! Copying over to the temporary config file!");
-                    System.out.println("----------------------------------------");
-                    writer.write(next + "\n");
-                }
-            }
-            System.out.println("No more lines found.");
-            System.out.println("----------------------------------------");
-
-            loadReader.close();
-            writer.close();
-
-            System.out.println("Deleting config.yml");
-            if (!configFile.delete()) {
-                System.out.println("Something went wrong deleting the config file!");
-            }
-
-            System.out.println("Renaming temporary config to config.yml");
-            if (!tempFile.renameTo(new File("./plugins/MedievalFactions/config.yml"))) {
-                System.out.println("Something went wrong renaming the temporary config!");
-            }
-
-        } catch (Exception e) {
-            System.out.println("There was a problem deleting the config option.");
-            e.printStackTrace();
+        if (main.getConfig().isInt("hourlyPowerIncreaseAmount")) {
+            main.getConfig().set("hourlyPowerIncreaseAmount", null);
         }
+
+        if (main.getConfig().isInt("maxPowerLevel")) {
+            main.getConfig().set("maxPowerLevel", null);
+        }
+
     }
 
     public void saveConfigDefaults() {

--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -5,6 +5,7 @@ import factionsystem.Main;
 import java.io.*;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Scanner;
 
 public class ConfigSubsystem {
 
@@ -62,11 +63,6 @@ public class ConfigSubsystem {
             main.getConfig().addDefault("warsRequiredForPVP", true);
         }
 
-        if (!main.getConfig().isBoolean("officerLimit")) {
-            System.out.println("officerLimit not set! Setting to default!");
-            main.getConfig().addDefault("officerLimit", 0);
-        }
-
         if (!main.getConfig().isDouble("factionOwnerMultiplier")) {
             System.out.println("factionOwnerMultiplier not set! Setting to default");
             main.getConfig().addDefault("factionOwnerMultiplier", 2.0);
@@ -94,35 +90,29 @@ public class ConfigSubsystem {
         }
     }
 
-    // Credit: https://stackoverflow.com/questions/1377279/find-a-line-in-a-file-and-remove-it
     private void deleteConfigOption(String option) {
+        File configFile = new File("/plugins/MedievalFactions/config.yml");
+        File tempFile = new File("/plugins/MedievalFactions/temp-config.yml");
         System.out.println("Attempting to delete old config option: " + option);
         try {
-            // iterate through lines in config.yml
-            File inputFile = new File("/plugins/MedievalFactions/config.yml");
-            File tempFile = new File("/plugins/MedievalFactions/temp-config.yml");
-
-            BufferedReader reader = new BufferedReader(new FileReader(inputFile));
-            BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile));
-
-            String lineToRemove = option;
+            Scanner scanner = new Scanner(configFile);
+            FileWriter writer = new FileWriter(tempFile);
             String currentLine;
 
-            while((currentLine = reader.readLine()) != null) {
-                // trim newline when comparing with lineToRemove
-                String trimmedLine = currentLine.trim();
-                if(trimmedLine.contains(lineToRemove)) {
-                    System.out.println("Found old config option: " + option);
-                    continue;
+            while((currentLine = scanner.nextLine()) != null) {
+                if(!currentLine.contains(option)) {
+                    writer.write(currentLine);
                 }
-                writer.write(currentLine + System.getProperty("line.separator"));
             }
+            configFile.delete();
+            tempFile.renameTo(configFile);
+
             writer.close();
-            reader.close();
-            tempFile.renameTo(inputFile);
+            scanner.close();
         }
         catch(Exception e) {
             System.out.println("Something went wrong when deleting a config option.");
+            e.printStackTrace();
         }
     }
 

--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -5,7 +5,6 @@ import factionsystem.Main;
 import java.io.*;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Scanner;
 
 public class ConfigSubsystem {
 

--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -28,7 +28,7 @@ public class ConfigSubsystem {
         }
 
         // add defaults if they don't exist
-        if (!main.getConfig().isInt("initialMaxPowerLevel")) { // TODO: change all references to maxPowerLevel
+        if (!main.getConfig().isInt("initialMaxPowerLevel")) {
             System.out.println("Max power level not set! Setting to default!");
             main.getConfig().addDefault("initialMaxPowerLevel", 20);
         }
@@ -40,9 +40,9 @@ public class ConfigSubsystem {
             System.out.println("Mobs spawn in faction territory not set! Setting to default!");
             main.getConfig().addDefault("mobsSpawnInFactionTerritory", false);
         }
-        if (!main.getConfig().isInt("powerIncreaseAmount")) { // TODO: change all references to hourlyPowerIncreaseAmount
+        if (!main.getConfig().isInt("powerIncreaseAmount")) {
             System.out.println("Hourly power increase amount not set! Setting to default!");
-            main.getConfig().addDefault("hourlyPowerIncreaseAmount", 2);
+            main.getConfig().addDefault("powerIncreaseAmount", 2);
         }
         if (!main.getConfig().isBoolean("laddersPlaceableInEnemyFactionTerritory")) {
             System.out.println("Ladders placeable in enemy faction territory not set! Setting to default!");
@@ -130,7 +130,7 @@ public class ConfigSubsystem {
         main.getConfig().addDefault("version", main.version);
         main.getConfig().addDefault("maxPowerLevel", 20);
         main.getConfig().addDefault("initialPowerLevel", 5);
-        main.getConfig().addDefault("hourlyPowerIncreaseAmount", 2);
+        main.getConfig().addDefault("powerIncreaseAmount", 2);
         main.getConfig().addDefault("mobsSpawnInFactionTerritory", false);
         main.getConfig().addDefault("laddersPlaceableInEnemyFactionTerritory", true);
         main.getConfig().addDefault("minutesBeforeInitialPowerIncrease", 30);

--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -91,13 +91,14 @@ public class ConfigSubsystem {
     }
 
     private void deleteConfigOption(String option) {
-        File configFile = new File("./plugins/MedievalFactions/config.yml");
         System.out.println("Attempting to delete old config option: " + option);
         try {
             System.out.println("Creating temporary config file");
             File tempFile = new File("./plugins/MedievalFactions/temp-config.yml");
-            Scanner loadReader = new Scanner(configFile);
             FileWriter writer = new FileWriter(tempFile);
+
+            File configFile = new File("./plugins/MedievalFactions/config.yml");
+            Scanner loadReader = new Scanner(configFile);
 
             // actual loading
             while (loadReader.hasNextLine()) {
@@ -110,16 +111,25 @@ public class ConfigSubsystem {
                 else {
                     System.out.println("Line does not contain the option! Copying over to the temporary config file!");
                     System.out.println("----------------------------------------");
-                    writer.write(next);
+                    writer.write(next + "\n");
                 }
             }
             System.out.println("No more lines found.");
             System.out.println("----------------------------------------");
 
-            System.out.println("Deleting config.yml");
-            configFile.delete();
-
             loadReader.close();
+            writer.close();
+
+            System.out.println("Deleting config.yml");
+            if (!configFile.delete()) {
+                System.out.println("Something went wrong deleting the config file!");
+            }
+
+            System.out.println("Renaming temporary config to config.yml");
+            if (!tempFile.renameTo(new File("./plugins/MedievalFactions/config.yml"))) {
+                System.out.println("Something went wrong renaming the temporary config!");
+            }
+
         } catch (Exception e) {
             System.out.println("There was a problem deleting the config option.");
             e.printStackTrace();

--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -96,6 +96,7 @@ public class ConfigSubsystem {
 
     // Credit: https://stackoverflow.com/questions/1377279/find-a-line-in-a-file-and-remove-it
     private void deleteConfigOption(String option) {
+        System.out.println("Attempting to delete old config option: " + option);
         try {
             // iterate through lines in config.yml
             File inputFile = new File("/plugins/MedievalFactions/config.yml");
@@ -110,7 +111,10 @@ public class ConfigSubsystem {
             while((currentLine = reader.readLine()) != null) {
                 // trim newline when comparing with lineToRemove
                 String trimmedLine = currentLine.trim();
-                if(trimmedLine.contains(lineToRemove)) continue;
+                if(trimmedLine.contains(lineToRemove)) {
+                    System.out.println("Found old config option: " + option);
+                    continue;
+                }
                 writer.write(currentLine + System.getProperty("line.separator"));
             }
             writer.close();
@@ -120,8 +124,6 @@ public class ConfigSubsystem {
         catch(Exception e) {
             System.out.println("Something went wrong when deleting a config option.");
         }
-
-
     }
 
     public void saveConfigDefaults() {

--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -91,21 +91,24 @@ public class ConfigSubsystem {
     }
 
     private void deleteConfigOption(String option) {
-        File configFile = new File("/plugins/MedievalFactions/config.yml");
-        File tempFile = new File("/plugins/MedievalFactions/temp-config.yml");
+        File configFile = new File("./plugins/MedievalFactions/config.yml");
+        File tempFile = new File("./plugins/MedievalFactions/temp-config.yml");
         System.out.println("Attempting to delete old config option: " + option);
         try {
             Scanner scanner = new Scanner(configFile);
             FileWriter writer = new FileWriter(tempFile);
             String currentLine;
 
-            while((currentLine = scanner.nextLine()) != null) {
+            while(scanner.hasNextLine() && ((currentLine = scanner.nextLine()) != null)) {
                 if(!currentLine.contains(option)) {
-                    writer.write(currentLine);
+                    System.out.println("Found old config option: " + option + ". Writing to new file.");
+                    writer.write(currentLine + "\n");
                 }
             }
+
             configFile.delete();
-            tempFile.renameTo(configFile);
+            File newFile = new File("./plugins/MedievalFactions/config.yml");
+            tempFile.renameTo(newFile);
 
             writer.close();
             scanner.close();

--- a/src/main/java/factionsystem/Subsystems/StorageSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/StorageSubsystem.java
@@ -197,7 +197,7 @@ public class StorageSubsystem {
             // actual loading
             while (loadReader.hasNextLine()) {
                 String nextName = loadReader.nextLine();
-                Faction temp = new Faction(nextName, main.getConfig().getInt("maxPowerLevel"), main); // uses server constructor, only temporary
+                Faction temp = new Faction(nextName, main.getConfig().getInt("initialMaxPowerLevel"), main); // uses server constructor, only temporary
                 temp.legacyLoad(nextName + ".txt"); // provides owner field among other things
 
                 // existence check

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -241,10 +241,10 @@ public class UtilitySubsystem {
         Bukkit.getScheduler().scheduleSyncRepeatingTask(main, new Runnable() {
             @Override
             public void run() {
-                System.out.println("Medieval Factions is increasing the power of every player by " + main.getConfig().getInt("hourlyPowerIncreaseAmount") + " if their power is below " + main.getConfig().getInt("maxPowerLevel") + ". This will happen every " + main.getConfig().getInt("minutesBetweenPowerIncreases") + " minutes.");
+                System.out.println("Medieval Factions is increasing the power of every player by " + main.getConfig().getInt("hourlyPowerIncreaseAmount") + " if their power is below " + main.getConfig().getInt("initialMaxPowerLevel") + ". This will happen every " + main.getConfig().getInt("minutesBetweenPowerIncreases") + " minutes.");
                 for (PlayerPowerRecord powerRecord : main.playerPowerRecords) {
                     try {
-                        if (powerRecord.getPowerLevel() < main.getConfig().getInt("maxPowerLevel")) {
+                        if (powerRecord.getPowerLevel() < main.getConfig().getInt("initialMaxPowerLevel")) {
                             if (getServer().getPlayer(powerRecord.getPlayerUUID()).isOnline()) {
                                 powerRecord.increasePower();
                                 getServer().getPlayer(powerRecord.getPlayerUUID()).sendMessage(ChatColor.GREEN + "You feel stronger. Your power has increased by " + main.getConfig().getInt("hourlyPowerIncreaseAmount") + ".");

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -561,7 +561,7 @@ public class UtilitySubsystem {
         // this piece of code is to fix config values not matching when updating to v3.3 (after v3.3 there is version mismatch handling)
         if (!main.getConfig().isSet("version")) {
             System.out.println("Config.yml doesn't have version entry!");
-            handleVersionMismatch();
+            main.config.handleVersionMismatch();
         }
     }
 
@@ -677,94 +677,6 @@ public class UtilitySubsystem {
         }
 
         return null;
-    }
-
-    public void handleVersionMismatch() {
-        // set version
-        if (!main.getConfig().isString("version")) {
-            System.out.println("Version not set! Setting version to " + main.version);
-            main.getConfig().addDefault("version", main.version);
-        }
-        else {
-            System.out.println("Version set but mismatched! Setting version to " + main.version);
-            main.getConfig().set("version", main.version);
-        }
-
-        // add defaults if they don't exist
-        if (!main.getConfig().isInt("maxPowerLevel")) {
-            System.out.println("Max power level not set! Setting to default!");
-            main.getConfig().addDefault("maxPowerLevel", 20);
-        }
-        if (!main.getConfig().isInt("initialPowerLevel")) {
-            System.out.println("Initial power level not set! Setting to default!");
-            main.getConfig().addDefault("initialPowerLevel", 5);
-        }
-        if (!main.getConfig().isBoolean("mobsSpawnInFactionTerritory")) {
-            System.out.println("Mobs spawn in faction territory not set! Setting to default!");
-            main.getConfig().addDefault("mobsSpawnInFactionTerritory", false);
-        }
-        if (!main.getConfig().isInt("hourlyPowerIncreaseAmount")) {
-            System.out.println("Hourly power increase amount not set! Setting to default!");
-            main.getConfig().addDefault("hourlyPowerIncreaseAmount", 2);
-        }
-        if (!main.getConfig().isBoolean("laddersPlaceableInEnemyFactionTerritory")) {
-            System.out.println("Ladders placeable in enemy faction territory not set! Setting to default!");
-            main.getConfig().addDefault("laddersPlaceableInEnemyFactionTerritory", true);
-        }
-        if (!main.getConfig().isInt("minutesBeforeInitialPowerIncrease")) {
-            System.out.println("minutesBeforeInitialPowerIncrease not set! Setting to default!");
-            main.getConfig().addDefault("minutesBeforeInitialPowerIncrease", 30);
-        }
-        if (!main.getConfig().isInt("minutesBetweenPowerIncreases")) {
-            System.out.println("minutesBetweenPowerIncreases not set! Setting to default!");
-            main.getConfig().addDefault("minutesBetweenPowerIncreases", 60);
-        }
-
-        if (!main.getConfig().isBoolean("warsRequiredForPVP")) {
-            System.out.println("warsRequiredForPVP not set! Setting to default!");
-            main.getConfig().addDefault("warsRequiredForPVP", true);
-        }
-
-        if (!main.getConfig().isBoolean("officerLimit")) {
-            System.out.println("officerLimit not set! Setting to default!");
-            main.getConfig().addDefault("officerLimit", 0);
-        }
-
-        if (!main.getConfig().isDouble("factionOwnerMultiplier")) {
-            System.out.println("factionOwnerMultiplier not set! Setting to default");
-            main.getConfig().addDefault("factionOwnerMultiplier", 2.0);
-        }
-
-        if (!main.getConfig().isDouble("officerPerMemberCount")){
-            System.out.println("officerPerMemberCount is not set! Setting to default");
-            main.getConfig().addDefault("officerPerMemberCount", 5);
-        }
-
-        if (!main.getConfig().isDouble("factionOfficerMultiplier")){
-            System.out.println("factionOfficerMultiplier is not set! Setting to default");
-            main.getConfig().addDefault("factionOfficerMultiplier", 2.0);
-        }
-
-        main.getConfig().options().copyDefaults(true);
-        main.saveConfig();
-    }
-
-    public void saveConfigDefaults() {
-        main.getConfig().addDefault("version", main.version);
-        main.getConfig().addDefault("maxPowerLevel", 20);
-        main.getConfig().addDefault("initialPowerLevel", 5);
-        main.getConfig().addDefault("hourlyPowerIncreaseAmount", 2);
-        main.getConfig().addDefault("mobsSpawnInFactionTerritory", false);
-        main.getConfig().addDefault("laddersPlaceableInEnemyFactionTerritory", true);
-        main.getConfig().addDefault("minutesBeforeInitialPowerIncrease", 30);
-        main.getConfig().addDefault("minutesBetweenPowerIncreases", 60);
-        main.getConfig().addDefault("warsRequiredForPVP", true);
-        main.getConfig().addDefault("officerLimit", 0);
-        main.getConfig().addDefault("factionOwnerMultiplier", 2.0);
-        main.getConfig().addDefault("officerPerMemberCount", 5);
-        main.getConfig().addDefault("factionOfficerMultiplier", 1.5);
-        main.getConfig().options().copyDefaults(true);
-        main.saveConfig();
     }
 
     public void sendAllPlayersOnServerMessage(String message) {

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -25,7 +25,7 @@ public class UtilitySubsystem {
         main = plugin;
     }
 
-    // non-static methods
+    // non-static methodsow I 
     
     public ClaimedChunk isChunkClaimed(double x, double y, String world)
     {

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -241,13 +241,13 @@ public class UtilitySubsystem {
         Bukkit.getScheduler().scheduleSyncRepeatingTask(main, new Runnable() {
             @Override
             public void run() {
-                System.out.println("Medieval Factions is increasing the power of every player by " + main.getConfig().getInt("hourlyPowerIncreaseAmount") + " if their power is below " + main.getConfig().getInt("initialMaxPowerLevel") + ". This will happen every " + main.getConfig().getInt("minutesBetweenPowerIncreases") + " minutes.");
+                System.out.println("Medieval Factions is increasing the power of every player by " + main.getConfig().getInt("powerIncreaseAmount") + " if their power is below " + main.getConfig().getInt("initialMaxPowerLevel") + ". This will happen every " + main.getConfig().getInt("minutesBetweenPowerIncreases") + " minutes.");
                 for (PlayerPowerRecord powerRecord : main.playerPowerRecords) {
                     try {
                         if (powerRecord.getPowerLevel() < main.getConfig().getInt("initialMaxPowerLevel")) {
                             if (getServer().getPlayer(powerRecord.getPlayerUUID()).isOnline()) {
                                 powerRecord.increasePower();
-                                getServer().getPlayer(powerRecord.getPlayerUUID()).sendMessage(ChatColor.GREEN + "You feel stronger. Your power has increased by " + main.getConfig().getInt("hourlyPowerIncreaseAmount") + ".");
+                                getServer().getPlayer(powerRecord.getPlayerUUID()).sendMessage(ChatColor.GREEN + "You feel stronger. Your power has increased by " + main.getConfig().getInt("powerIncreaseAmount") + ".");
                             }
                         }
                     } catch (Exception ignored) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: MedievalFactions
-version: 3.4.3
+version: 3.4.4
 author: KingdomProgrammers
 main: factionsystem.Main
 api-version: 1.13


### PR DESCRIPTION
Everything is set up and ready to go... except for the method that does the actual deleting. I have set config-related methods into a Config Subsystem that also has a list of old config options. The console tells me it works but the file manager shows me that it lies.

I don't know why this doesn't work. If you guys want to try to run it and figure it out that would be awesome.