### PR TITLE
made power decreases only affect offline players by adding a ! to an if statement

### DIFF
--- a/src/main/java/factionsystem/EventHandlers/PlayerJoinEventHandler.java
+++ b/src/main/java/factionsystem/EventHandlers/PlayerJoinEventHandler.java
@@ -55,7 +55,6 @@ public class PlayerJoinEventHandler {
         		{
         			event.getPlayer().sendMessage(ChatColor.RED + "Your power has decayed by " + record.getPowerLost() + " since you last logged out. Your power is now " + newPower + ".");
         		}
-        		power.setPowerLevel(newPower);
         		record.setPowerLost(0);
         	}
         }

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -385,7 +385,7 @@ public class UtilitySubsystem {
     				{
     					isOnline = player.isOnline();
     				}
-    				if (isOnline && main.getConfig().getBoolean("powerDecreases")
+    				if (!isOnline && main.getConfig().getBoolean("powerDecreases")
     						&& record.getMinutesSinceLastLogout() > main.getConfig().getInt("minutesBeforePowerDecrease"))
     				{
     					record.incrementPowerLost();


### PR DESCRIPTION
Decided to take a quick break from HW and take a look at the power decrease code. Correct me if I'm wrong, but I'm pretty sure that the way it is programmed right now, power decreases will only affect online players. I added a ! to negate the isOnline check.

@philbgarner If you could review this PR whenever you have the chance (doesn't have to be today) that would be awsome. Since you programmed the original method, I want to verify that this merge commit will result in the behavior you intended.