### PR TITLE
Border claiming only

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ An open source minecraft plugin licensed under GPL3 for players to use to organi
 - 3.3 'Major Overhauls & Bug Fixes' update
 - 3.4 'Config Command + Bug Fix/Tweaks' update
 - 3.5 'Vassal Factions, Power Decay & Many Tweaks' update
+- 3.6 'Gates' (more to add)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>KingdomProgrammers</groupId>
     <artifactId>Medieval-Factions</artifactId>
-    <version>v3.5.1</version>
+    <version>v3.6</version>
     <packaging>jar</packaging>
 
     <name>Medieval Factions</name>

--- a/src/main/java/factionsystem/Commands/ClaimCommand.java
+++ b/src/main/java/factionsystem/Commands/ClaimCommand.java
@@ -1,0 +1,49 @@
+package factionsystem.Commands;
+
+import factionsystem.Main;
+import factionsystem.Objects.Faction;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import static factionsystem.Subsystems.UtilitySubsystem.*;
+
+public class ClaimCommand {
+
+    Main main = null;
+
+    public ClaimCommand(Main plugin) {
+        main = plugin;
+    }
+
+    public boolean claimChunk(CommandSender sender, String[] args) {
+        if (sender.hasPermission("mf.claim") || sender.hasPermission("mf.default")) {
+            if (sender instanceof Player) {
+                Player player = (Player) sender;
+
+                // if not at demesne limit
+                if (isInFaction(player.getUniqueId(), main.factions)) {
+                    Faction playersFaction = getPlayersFaction(player.getUniqueId(), main.factions);
+                    if (getChunksClaimedByFaction(playersFaction.getName(), main.claimedChunks) < playersFaction.getCumulativePowerLevel()) {
+                        main.utilities.addChunkAtPlayerLocation(player);
+                        return true;
+                    }
+                    else {
+                        player.sendMessage(ChatColor.RED + "You have reached your demesne limit! Invite more players to increase this.");
+                        return false;
+                    }
+                }
+                else {
+                    player.sendMessage(ChatColor.RED + "You must be in a faction to use this command.");
+                    return false;
+                }
+            }
+        }
+        else {
+            sender.sendMessage(ChatColor.RED + "Sorry! You need the following permission to use this command: 'mf.claim'");
+            return false;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/factionsystem/Commands/GateCommand.java
+++ b/src/main/java/factionsystem/Commands/GateCommand.java
@@ -47,31 +47,53 @@ public class GateCommand {
 						Faction faction = UtilitySubsystem.getPlayersFaction(player.getUniqueId(), main.factions);
 						if (faction != null)
 						{
-							player.sendMessage(ChatColor.AQUA + "Faction Gates");
-							for (Gate gate : faction.getGates())
+							if (faction.getGates().size() > 0)
 							{
-								player.sendMessage(ChatColor.AQUA + String.format("%s: %s", gate.getName(), gate.coordsToString()));
+								player.sendMessage(ChatColor.AQUA + "Faction Gates");
+								for (Gate gate : faction.getGates())
+								{
+									player.sendMessage(ChatColor.AQUA + String.format("%s: %s", gate.getName(), gate.coordsToString()));
+								}
+							}
+							else
+							{
+								player.sendMessage(ChatColor.RED + "Your fation has no gates defined.");
+								return;
 							}
 						}
 					}
 					if (args[1].equalsIgnoreCase("name"))
 					{
-						if (player.getLineOfSight((Set<Material>) null, 16).size() > 0)
+						
+						if (player.getTargetBlock(null, 16) != null)
+						//if (player.getLineOfSight((Set<Material>) null, 16).size() > 0)
 						{
-							if (UtilitySubsystem.isGateBlock(player.getLineOfSight((Set<Material>) null, 16).get(0), main.factions))
+							if (UtilitySubsystem.isGateBlock(player.getTargetBlock(null, 16), main.factions))
 							{
-								Gate gate = UtilitySubsystem.getGate(player.getLineOfSight((Set<Material>) null, 16).get(0), main.factions);
+								Gate gate = UtilitySubsystem.getGate(player.getTargetBlock(null, 16), main.factions);
 								if (args.length > 2)
 								{
 									String name = UtilitySubsystem.createStringFromArgIndexOnwards(2, args);
 									gate.setName(name);
+									player.sendMessage(ChatColor.AQUA + String.format("Changed gate name to '%s'.", gate.getName()));
+									return;
 								}
 								else
 								{
-									player.sendMessage(ChatColor.AQUA + String.format("%s Gate.", gate.getName()));
+									player.sendMessage(ChatColor.AQUA + String.format("That is the '%s' gate.", gate.getName()));
 									return;
 								}
 							}
+							else
+							{
+								player.sendMessage(ChatColor.RED + "Target block is not part of a gate.");
+								return;
+							}
+						}
+						else
+						{
+							player.sendMessage(ChatColor.RED + "No block detected to check for gate.");
+							return;
 						}
 					}						
 				}

--- a/src/main/java/factionsystem/EventHandlers/BlockBreakEventHandler.java
+++ b/src/main/java/factionsystem/EventHandlers/BlockBreakEventHandler.java
@@ -4,6 +4,7 @@ import factionsystem.Main;
 import factionsystem.Objects.ClaimedChunk;
 import factionsystem.Objects.Faction;
 import factionsystem.Objects.LockedBlock;
+import factionsystem.Objects.Gate;
 import factionsystem.Subsystems.UtilitySubsystem;
 
 import org.bukkit.ChatColor;
@@ -59,6 +60,18 @@ public class BlockBreakEventHandler {
 
                     	UtilitySubsystem.removeLock(event.getBlock(), main.lockedBlocks);
 
+                    }
+                    
+                    // if block is in a gate
+                    for (Gate gate : faction.getGates())
+                    {
+                    	System.out.println("Gate " + gate.getName() + "?");
+                    	if (gate.hasBlock(event.getBlock()))
+                    	{
+                    		event.setCancelled(true);
+                            player.sendMessage(ChatColor.RED + "This block is part of gate '" + gate.getName() + "'. You must remove the gate first.");
+                            return;
+                    	}
                     }
                 }
             }

--- a/src/main/java/factionsystem/EventHandlers/PlayerInteractEventHandler.java
+++ b/src/main/java/factionsystem/EventHandlers/PlayerInteractEventHandler.java
@@ -108,22 +108,38 @@ public class PlayerInteractEventHandler {
         			ClaimedChunk claim = UtilitySubsystem.getClaimedChunk(clickedBlock.getChunk().getX(), clickedBlock.getChunk().getZ(),
         					clickedBlock.getChunk().getWorld().getName(), main.claimedChunks);
         			Faction faction = UtilitySubsystem.getFaction(claim.getHolder(), main.factions);
-        			System.out.println("Lever check for faction " + faction.getName());
+
         			if (faction.hasGateTrigger(clickedBlock))
         			{
-        				System.out.println("Has gate check for faction " + faction.getName());
         				for (Gate g : faction.getGatesForTrigger(clickedBlock))
         				{
-        					System.out.println("Gate for trigger" + g.getName());
         					BlockData blockData = clickedBlock.getBlockData();
         					Powerable powerable = (Powerable) blockData;
         					if (powerable.isPowered())
         					{
-        						g.openGate();
+                				if (faction.getGatesForTrigger(clickedBlock).get(0).isReady())
+                				{
+                					g.openGate();
+                				}
+                				else
+                				{
+                					event.setCancelled(true);
+                					player.sendMessage(ChatColor.RED + "This gate is " + g.getStatus() + ", please wait.");
+                					return;
+                				}
         					}
         					else
         					{
-        						g.closeGate();
+                				if (faction.getGatesForTrigger(clickedBlock).get(0).isReady())
+                				{
+                					g.closeGate();
+                				}
+                				else
+                				{
+                					event.setCancelled(true);
+                					player.sendMessage(ChatColor.RED + "This gate is " + g.getStatus() + ", please wait.");
+                					return;
+                				}
         					}
         				}
             			return;

--- a/src/main/java/factionsystem/EventHandlers/PlayerLeaveEventHandler.java
+++ b/src/main/java/factionsystem/EventHandlers/PlayerLeaveEventHandler.java
@@ -21,6 +21,27 @@ public class PlayerLeaveEventHandler {
 	
 	public void handle(PlayerQuitEvent event)
 	{
+		if (main.lockingPlayers.contains(event.getPlayer().getUniqueId()))
+		{
+			main.lockingPlayers.remove(event.getPlayer().getUniqueId());
+		}
+		if (main.unlockingPlayers.contains(event.getPlayer().getUniqueId()))
+		{
+			main.unlockingPlayers.remove(event.getPlayer().getUniqueId());
+		}
+		if (main.playersGrantingAccess.containsKey(event.getPlayer().getUniqueId()))
+		{
+			main.playersGrantingAccess.remove(event.getPlayer().getUniqueId());
+		}
+		if (main.playersCheckingAccess.contains(event.getPlayer().getUniqueId()))
+		{
+			main.playersCheckingAccess.remove(event.getPlayer().getUniqueId());
+		}
+		if (main.playersRevokingAccess.containsKey(event.getPlayer().getUniqueId()))
+		{
+			main.playersRevokingAccess.remove(event.getPlayer().getUniqueId());
+		}
+			
     	PlayerActivityRecord record = UtilitySubsystem.getPlayerActivityRecord(event.getPlayer().getUniqueId(), main.playerActivityRecords);
     	if (record != null)
     	{

--- a/src/main/java/factionsystem/Main.java
+++ b/src/main/java/factionsystem/Main.java
@@ -36,7 +36,7 @@ import java.util.UUID;
 public class Main extends JavaPlugin implements Listener {
 
     // version
-    public static String version = "v3.5.1";
+    public static String version = "v3.6";
 
     // subsystems
     public StorageSubsystem storage = new StorageSubsystem(this);

--- a/src/main/java/factionsystem/Objects/Faction.java
+++ b/src/main/java/factionsystem/Objects/Faction.java
@@ -382,9 +382,7 @@ public class Faction {
         {
 	        for (String item : gateList)
 	        {
-	        	System.out.println("Loading " + item);
 	        	Gate g = Gate.load(item, main);
-	        	System.out.println("Gate trigger at " + g.coordsToString());
 	        	gates.add(g);
 	        }
         }

--- a/src/main/java/factionsystem/Objects/Gate.java
+++ b/src/main/java/factionsystem/Objects/Gate.java
@@ -135,9 +135,19 @@ public class Gate {
 		return open ? true : false;
 	}
 	
+	public boolean isReady()
+	{
+		return gateStatus.equals(GateStatus.READY); 
+	}
+	
 	public boolean isClosed()
 	{
 		return open ? false : true;
+	}
+	
+	public String getStatus()
+	{
+		return gateStatus.toString().substring(0,1).toUpperCase() + gateStatus.toString().substring(1).toLowerCase();
 	}
 	
 	public GateCoord getTrigger()
@@ -439,13 +449,17 @@ public class Gate {
 	        					b.setType(Material.AIR);
 	        					getWorld().playSound(b.getLocation(), soundEffect, 0.1f, 0.1f);
 	        				}
-	        				if (blockY == bottomY + 1)
-	        				{
-	        					gateStatus = GateStatus.READY;
-	        				}
 	                    }
 	                }, c * 10);
 				}
+				Bukkit.getScheduler().runTaskLater(main, new Runnable() {
+					Block b;
+                    @Override
+                    public void run() {
+    					gateStatus = GateStatus.READY;
+    					open = true;
+                    }
+				}, (topY - bottomY + 2) * 10);
 			}
 			else if (isParallelToZ())
 			{
@@ -483,13 +497,18 @@ public class Gate {
 	        					b.setType(Material.AIR);
 	        					getWorld().playSound(b.getLocation(), soundEffect, 0.1f, 0.1f);
 	        				}
-	        				if (blockY == bottomY + 1)
-	        				{
-	        					gateStatus = GateStatus.READY;
-	        				}
 	                    }
 	                }, c * 10);
-				}			
+				}
+				Bukkit.getScheduler().runTaskLater(main, new Runnable() {
+					Block b;
+                    @Override
+                    public void run() {
+    					gateStatus = GateStatus.READY;
+    					open = true;
+                    }
+				}, (topY - bottomY + 2) * 10);
+
 			}
 			
 		}
@@ -546,13 +565,17 @@ public class Gate {
 	        					b.setType(material);
 	        					getWorld().playSound(b.getLocation(), soundEffect, 0.1f, 0.1f);
 	        				}
-	        				if (blockY == bottomY + 1)
-	        				{
-	        					gateStatus = GateStatus.READY;
-	        				}
 	                    }
 	                }, c * 10);
 				}
+				Bukkit.getScheduler().runTaskLater(main, new Runnable() {
+					Block b;
+                    @Override
+                    public void run() {
+    					gateStatus = GateStatus.READY;
+    					open = false;
+                    }
+				}, (topY - bottomY + 2) * 10);
 			}
 			else if (isParallelToZ())
 			{
@@ -591,13 +614,17 @@ public class Gate {
 	        					b.getState().update(true);
 	        					getWorld().playSound(b.getLocation(), soundEffect, 0.1f, 0.1f);
 	        				}
-	        				if (blockY == bottomY + 1)
-	        				{
-	        					gateStatus = GateStatus.READY;
-	        				}
 	                    }
 	                }, c * 10);
-				}			
+				}
+				Bukkit.getScheduler().runTaskLater(main, new Runnable() {
+					Block b;
+                    @Override
+                    public void run() {
+    					gateStatus = GateStatus.READY;
+    					open = false;
+                    }
+				}, (topY - bottomY + 2) * 10);
 			}
 		}
 		else

--- a/src/main/java/factionsystem/Objects/Gate.java
+++ b/src/main/java/factionsystem/Objects/Gate.java
@@ -96,18 +96,13 @@ public class Gate {
         {
 	        GateJson data = gson.fromJson(jsonData, GateJson.class);
 	        
-	        System.out.println("Loading world " + data.world);
-	        
 	        newGate.world = data.world;
 	        newGate.coord1 = new GateCoord();
 	        newGate.coord1 = GateCoord.fromString(data.coord1, main);
 	        newGate.coord2 = new GateCoord();
 	        newGate.coord2 = GateCoord.fromString(data.coord2, main);
-	        System.out.println("Loaded coords, loading trigger.");
 	        newGate.trigger = new GateCoord();
 	        newGate.trigger = GateCoord.fromString(data.triggerCoord, main);
-	        System.out.println(newGate.coordsToString());
-	        System.out.println("Loading material " + data.material);
 	        newGate.material = Material.getMaterial(data.material);
         }
         catch (Exception e)
@@ -696,13 +691,50 @@ public class Gate {
 	
 	public boolean hasBlock(Block targetBlock)
 	{
-		if (targetBlock.getX() >= coord1.getX() && targetBlock.getX() <= coord2.getX()
-				&& targetBlock.getY() >= coord1.getY() && targetBlock.getY() <= coord2.getY()
-				&& targetBlock.getZ() >= coord1.getZ() && targetBlock.getZ() <= coord2.getZ()
+		
+		int topY = coord1.getY();
+		int bottomY = coord2.getY();
+		if (coord2.getY() > coord1.getY())
+		{
+			topY = coord2.getY();
+			bottomY = coord1.getY();
+		}
+		
+		int _leftZ = coord1.getZ();
+		int _rightZ = coord2.getZ();
+
+		if (coord2.getZ() < coord1.getZ())
+		{
+			_leftZ = coord2.getZ();
+			_rightZ = coord1.getZ();
+		}
+		int leftZ = _leftZ;
+		int rightZ = _rightZ;
+		
+		int _leftX = coord1.getX();
+		int _rightX = coord2.getX();
+		if (coord2.getX() < coord1.getX())
+		{
+			_leftX = coord2.getX();
+			_rightX = coord1.getX();
+		}
+
+		int leftX = _leftX;
+		int rightX = _rightX;
+
+		if (targetBlock.getX() >= leftX && targetBlock.getX() <= rightX
+				&& targetBlock.getY() >= bottomY && targetBlock.getY() <= topY
+				&& targetBlock.getZ() >= leftZ && targetBlock.getZ() <= rightZ
 				&& targetBlock.getWorld().getName().equalsIgnoreCase(coord1.getWorld()))
 		{
 			return true;
 		}
+		
+		if (trigger.equals(targetBlock))
+		{
+			return true;
+		}
+		
 		return false;
 	}
 	

--- a/src/main/java/factionsystem/Subsystems/CommandSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/CommandSubsystem.java
@@ -223,32 +223,8 @@ public class CommandSubsystem {
 
                 // claim command
                 if (args[0].equalsIgnoreCase("claim")) {
-                    if (sender.hasPermission("mf.claim") || sender.hasPermission("mf.default")) {
-                        if (sender instanceof Player) {
-                            Player player = (Player) sender;
-
-                            // if not at demesne limit
-                            if (isInFaction(player.getUniqueId(), main.factions)) {
-                                Faction playersFaction = getPlayersFaction(player.getUniqueId(), main.factions);
-                                if (getChunksClaimedByFaction(playersFaction.getName(), main.claimedChunks) < playersFaction.getCumulativePowerLevel()) {
-                                    main.utilities.addChunkAtPlayerLocation(player);
-                                    return true;
-                                }
-                                else {
-                                    player.sendMessage(ChatColor.RED + "You have reached your demesne limit! Invite more players to increase this.");
-                                    return false;
-                                }
-                            }
-                            else {
-                                player.sendMessage(ChatColor.RED + "You must be in a faction to use this command.");
-                                return false;
-                            }
-                        }
-                    }
-                    else {
-                        sender.sendMessage(ChatColor.RED + "Sorry! You need the following permission to use this command: 'mf.claim'");
-                        return false;
-                    }
+                    ClaimCommand command = new ClaimCommand(main);
+                    return command.claimChunk(sender, args);
                 }
 
                 // unclaim command

--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -111,8 +111,12 @@ public class ConfigSubsystem {
         if (!main.getConfig().isInt("factionMaxGateArea")) {
         	System.out.println("factionMaxGateArea not set! Setting to default!");
             main.getConfig().addDefault("factionMaxGateArea", 64);
-        }        
-        
+        }
+        if (!main.getConfig().isBoolean("borderConqueringOnly")) {
+            System.out.println("borderConqueringOnly not set! Setting to default!");
+            main.getConfig().addDefault("borderConqueringOnly", true);
+        }
+
         deleteOldConfigOptionsIfPresent();
 
         main.getConfig().options().copyDefaults(true);
@@ -163,7 +167,8 @@ public class ConfigSubsystem {
             else if (option.equalsIgnoreCase("mobsSpawnInFactionTerritory")
                     || option.equalsIgnoreCase("laddersPlaceableInEnemyFactionTerritory")
                     || option.equalsIgnoreCase("warsRequiredForPVP")
-                    || option.equalsIgnoreCase("powerDecreases")) {
+                    || option.equalsIgnoreCase("powerDecreases")
+                    || option.equalsIgnoreCase("borderConqueringOnly")) {
                 main.getConfig().set(option, Boolean.parseBoolean(value));
                 player.sendMessage(ChatColor.GREEN + "Boolean set!");
                 return;
@@ -204,6 +209,7 @@ public class ConfigSubsystem {
         main.getConfig().addDefault("factionMaxNameLength", 20);
         main.getConfig().addDefault("factionMaxNumberGates", 5);
         main.getConfig().addDefault("factionMaxGateArea", 64);
+        main.getConfig().addDefault("borderConqueringOnly", true);
         main.getConfig().options().copyDefaults(true);
         main.saveConfig();
     }
@@ -227,7 +233,8 @@ public class ConfigSubsystem {
                 + ", powerDecreaseAmount: " + main.getConfig().getInt("powerDecreaseAmount")
                 + ", factionMaxNameLength: " + main.getConfig().getInt("factionMaxNameLength")
 		        + ", factionMaxNumberGates: " + main.getConfig().getInt("factionMaxNumberGates")
-		        + ", factionMaxGateArea: " + main.getConfig().getInt("factionMaxGateArea"));
+		        + ", factionMaxGateArea: " + main.getConfig().getInt("factionMaxGateArea")
+                + ", factionMaxGateArea: " + main.getConfig().getInt("borderConqueringOnly"));
     }
 
 }

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -84,6 +84,17 @@ public class UtilitySubsystem {
                                         // is at war with target faction
                                         if (faction.isEnemy(targetFaction.getName())) {
 
+                                            // if border conquering only flag is toggled
+                                            if (main.getConfig().getBoolean("borderConqueringOnly")) {
+
+                                                // ensure that claimed chunk is a border chunk
+                                                if (!isBorderChunk(chunk)) {
+                                                    player.sendMessage(ChatColor.RED + "You can only conquer non-border chunks! (claimed chunks that are not surrounded by 4 claimed chunks)");
+                                                    return;
+                                                }
+
+                                            }
+
                                             // remove locks on this chunk
                                             Iterator<LockedBlock> itr = main.lockedBlocks.iterator();
                                             while (itr.hasNext()) {
@@ -131,6 +142,49 @@ public class UtilitySubsystem {
                 return;
             }
         }
+    }
+
+    // this method checks if a claimed chunk is not surrounded by 4 claimed chunks (claimed by the same faction)
+    public boolean isBorderChunk(ClaimedChunk chunk) {
+        if (chunk != null) {
+            // check northern chunk
+            if (!isClaimed(getNorthernChunk(chunk).getChunk(), main.claimedChunks) && getNorthernChunk(chunk).getHolder().equalsIgnoreCase(chunk.getHolder())) {
+                return true;
+            }
+
+            // check eastern chunk
+            if (!isClaimed(getEasternChunk(chunk).getChunk(), main.claimedChunks) && getNorthernChunk(chunk).getHolder().equalsIgnoreCase(chunk.getHolder())) {
+                return true;
+            }
+
+            // check southern chunk
+            if (!isClaimed(getSouthernChunk(chunk).getChunk(), main.claimedChunks) && getNorthernChunk(chunk).getHolder().equalsIgnoreCase(chunk.getHolder())) {
+                return true;
+            }
+
+            // check western chunk
+            if (!isClaimed(getWesternChunk(chunk).getChunk(), main.claimedChunks) && getNorthernChunk(chunk).getHolder().equalsIgnoreCase(chunk.getHolder())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public ClaimedChunk getNorthernChunk(ClaimedChunk chunk) {
+        return getClaimedChunk(chunk.getChunk().getX(), chunk.getChunk().getZ() + 1, chunk.getWorld(), main.claimedChunks);
+    }
+
+    public ClaimedChunk getEasternChunk(ClaimedChunk chunk) {
+        return getClaimedChunk(chunk.getChunk().getX() + 1, chunk.getChunk().getZ(), chunk.getWorld(), main.claimedChunks);
+    }
+
+    public ClaimedChunk getSouthernChunk(ClaimedChunk chunk) {
+        return getClaimedChunk(chunk.getChunk().getX(), chunk.getChunk().getZ() - 1, chunk.getWorld(), main.claimedChunks);
+    }
+
+    public ClaimedChunk getWesternChunk(ClaimedChunk chunk) {
+        return getClaimedChunk(chunk.getChunk().getX() - 1, chunk.getChunk().getZ(), chunk.getWorld(), main.claimedChunks);
     }
 
     public void removeChunkAtPlayerLocation(Player player) {

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -148,24 +148,33 @@ public class UtilitySubsystem {
     public boolean isBorderChunk(ClaimedChunk chunk) {
         if (chunk != null) {
             // check northern chunk
-            if (!isClaimed(getNorthernChunk(chunk).getChunk(), main.claimedChunks) && getNorthernChunk(chunk).getHolder().equalsIgnoreCase(chunk.getHolder())) {
-                return true;
+            if (getNorthernChunk(chunk) != null) {
+                if (getNorthernChunk(chunk).getHolder().equalsIgnoreCase(chunk.getHolder())) {
+                    return true;
+                }
             }
 
             // check eastern chunk
-            if (!isClaimed(getEasternChunk(chunk).getChunk(), main.claimedChunks) && getNorthernChunk(chunk).getHolder().equalsIgnoreCase(chunk.getHolder())) {
-                return true;
+            if (getEasternChunk(chunk) != null) {
+                if (getEasternChunk(chunk).getHolder().equalsIgnoreCase(chunk.getHolder())) {
+                    return true;
+                }
             }
 
             // check southern chunk
-            if (!isClaimed(getSouthernChunk(chunk).getChunk(), main.claimedChunks) && getNorthernChunk(chunk).getHolder().equalsIgnoreCase(chunk.getHolder())) {
-                return true;
+            if (getSouthernChunk(chunk) != null) {
+                if (getSouthernChunk(chunk).getHolder().equalsIgnoreCase(chunk.getHolder())) {
+                    return true;
+                }
             }
 
             // check western chunk
-            if (!isClaimed(getWesternChunk(chunk).getChunk(), main.claimedChunks) && getNorthernChunk(chunk).getHolder().equalsIgnoreCase(chunk.getHolder())) {
-                return true;
+            if (getWesternChunk(chunk) != null) {
+                if (getWesternChunk(chunk).getHolder().equalsIgnoreCase(chunk.getHolder())) {
+                    return true;
+                }
             }
+
         }
 
         return false;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: MedievalFactions
-version: 3.5.1
+version: 3.6
 author: KingdomProgrammers
 main: factionsystem.Main
 api-version: 1.13


### PR DESCRIPTION
This still needs to be tested but in theory this should prevent players from conquering claimed chunks unless they are not border chunks.

Border chunks are defined as claimed chunks surrounded by claimed chunks on all four sides (claimed by the same faction).