### PR TITLE
Better Conquering

### DIFF
--- a/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/ConfigSubsystem.java
@@ -108,11 +108,17 @@ public class ConfigSubsystem {
         	System.out.println("factionMaxNumberGates not set! Setting to default!");
             main.getConfig().addDefault("factionMaxNumberGates", 5);
         }
+
         if (!main.getConfig().isInt("factionMaxGateArea")) {
         	System.out.println("factionMaxGateArea not set! Setting to default!");
             main.getConfig().addDefault("factionMaxGateArea", 64);
-        }        
-        
+        }
+
+        if (!main.getConfig().isBoolean("surroundedChunksProtected")) {
+            System.out.println("surroundedChunksProtected not set! Setting to default!");
+            main.getConfig().addDefault("surroundedChunksProtected", true);
+        }
+
         deleteOldConfigOptionsIfPresent();
 
         main.getConfig().options().copyDefaults(true);
@@ -163,7 +169,8 @@ public class ConfigSubsystem {
             else if (option.equalsIgnoreCase("mobsSpawnInFactionTerritory")
                     || option.equalsIgnoreCase("laddersPlaceableInEnemyFactionTerritory")
                     || option.equalsIgnoreCase("warsRequiredForPVP")
-                    || option.equalsIgnoreCase("powerDecreases")) {
+                    || option.equalsIgnoreCase("powerDecreases")
+                    || option.equalsIgnoreCase("surroundedChunksProtected")) {
                 main.getConfig().set(option, Boolean.parseBoolean(value));
                 player.sendMessage(ChatColor.GREEN + "Boolean set!");
                 return;
@@ -204,6 +211,7 @@ public class ConfigSubsystem {
         main.getConfig().addDefault("factionMaxNameLength", 20);
         main.getConfig().addDefault("factionMaxNumberGates", 5);
         main.getConfig().addDefault("factionMaxGateArea", 64);
+        main.getConfig().addDefault("surroundedChunksProtected", true);
         main.getConfig().options().copyDefaults(true);
         main.saveConfig();
     }
@@ -227,7 +235,8 @@ public class ConfigSubsystem {
                 + ", powerDecreaseAmount: " + main.getConfig().getInt("powerDecreaseAmount")
                 + ", factionMaxNameLength: " + main.getConfig().getInt("factionMaxNameLength")
 		        + ", factionMaxNumberGates: " + main.getConfig().getInt("factionMaxNumberGates")
-		        + ", factionMaxGateArea: " + main.getConfig().getInt("factionMaxGateArea"));
+		        + ", factionMaxGateArea: " + main.getConfig().getInt("factionMaxGateArea")
+                + ", surroundedChunksProtected: " + main.getConfig().getBoolean("surroundedChunksProtected"));
     }
 
 }

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -1159,4 +1159,21 @@ public class UtilitySubsystem {
         return origin.getWorld().getChunkAt(xpos, zpos);
     }
 
+    public ClaimedChunk getClaimedChunk(Chunk chunk) {
+        return getClaimedChunk(chunk.getX(), chunk.getZ(), chunk.getWorld().getName(), main.claimedChunks);
+    }
+
+    // this will return true if the chunks to the North, East, South and West of the target are claimed by the same faction as the target
+    public boolean isClaimedChunkSurroundedByChunksClaimedBySameFaction(ClaimedChunk target) {
+        boolean northernChunkClaimedBySameFaction = target.getHolder().equalsIgnoreCase(getClaimedChunk(getChunkByDirection(target.getChunk(), "north")).getHolder());
+        boolean easternChunkClaimedBySameFaction = target.getHolder().equalsIgnoreCase(getClaimedChunk(getChunkByDirection(target.getChunk(), "east")).getHolder());
+        boolean southernChunkClaimedBySameFaction = target.getHolder().equalsIgnoreCase(getClaimedChunk(getChunkByDirection(target.getChunk(), "south")).getHolder());
+        boolean westernChunkClaimedBySameFaction = target.getHolder().equalsIgnoreCase(getClaimedChunk(getChunkByDirection(target.getChunk(), "west")).getHolder());
+
+        return (northernChunkClaimedBySameFaction &&
+                easternChunkClaimedBySameFaction &&
+                southernChunkClaimedBySameFaction &&
+                westernChunkClaimedBySameFaction);
+    }
+
 }

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -1174,10 +1174,24 @@ public class UtilitySubsystem {
 
     // this will return true if the chunks to the North, East, South and West of the target are claimed by the same faction as the target
     public boolean isClaimedChunkSurroundedByChunksClaimedBySameFaction(ClaimedChunk target) {
-        boolean northernChunkClaimedBySameFaction = target.getHolder().equalsIgnoreCase(getClaimedChunk(getChunkByDirection(target.getChunk(), "north")).getHolder());
-        boolean easternChunkClaimedBySameFaction = target.getHolder().equalsIgnoreCase(getClaimedChunk(getChunkByDirection(target.getChunk(), "east")).getHolder());
-        boolean southernChunkClaimedBySameFaction = target.getHolder().equalsIgnoreCase(getClaimedChunk(getChunkByDirection(target.getChunk(), "south")).getHolder());
-        boolean westernChunkClaimedBySameFaction = target.getHolder().equalsIgnoreCase(getClaimedChunk(getChunkByDirection(target.getChunk(), "west")).getHolder());
+        ClaimedChunk northernClaimedChunk = getClaimedChunk(getChunkByDirection(target.getChunk(), "north"));
+        ClaimedChunk easternClaimedChunk = getClaimedChunk(getChunkByDirection(target.getChunk(), "east");
+        ClaimedChunk southernClaimedChunk = getClaimedChunk(getChunkByDirection(target.getChunk(), "south");
+        ClaimedChunk westernClaimedChunk = getClaimedChunk(getChunkByDirection(target.getChunk(), "west");
+
+        if (northernClaimedChunk == null ||
+            easternClaimedChunk == null ||
+            southernClaimedChunk == null ||
+            westernClaimedChunk == null) {
+
+            return false;
+
+        }
+
+        boolean northernChunkClaimedBySameFaction = target.getHolder().equalsIgnoreCase(northernClaimedChunk.getHolder());
+        boolean easternChunkClaimedBySameFaction = target.getHolder().equalsIgnoreCase(easternClaimedChunk.getHolder());
+        boolean southernChunkClaimedBySameFaction = target.getHolder().equalsIgnoreCase(southernClaimedChunk.getHolder());
+        boolean westernChunkClaimedBySameFaction = target.getHolder().equalsIgnoreCase(westernClaimedChunk.getHolder());
 
         return (northernChunkClaimedBySameFaction &&
                 easternChunkClaimedBySameFaction &&

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -1134,4 +1134,29 @@ public class UtilitySubsystem {
         return -1;
     }
 
+    public Chunk getChunkByDirection(Chunk origin, String direction) {
+
+        int xpos = -1;
+        int zpos = -1;
+
+        if (direction.equalsIgnoreCase("north")) {
+            xpos = origin.getX();
+            zpos = origin.getZ() + 1;
+        }
+        if (direction.equalsIgnoreCase("east")) {
+            xpos = origin.getX() + 1;
+            zpos = origin.getZ();
+        }
+        if (direction.equalsIgnoreCase("south")) {
+            xpos = origin.getX();
+            zpos = origin.getZ() - 1;
+        }
+        if (direction.equalsIgnoreCase("west")) {
+            xpos = origin.getX() - 1;
+            zpos = origin.getZ();
+        }
+
+        return origin.getWorld().getChunkAt(xpos, zpos);
+    }
+
 }

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -85,6 +85,13 @@ public class UtilitySubsystem {
                                         // is at war with target faction
                                         if (faction.isEnemy(targetFaction.getName())) {
 
+                                            if (isClaimedChunkSurroundedByChunksClaimedBySameFaction(chunk)) {
+                                                player.sendMessage(ChatColor.RED + "Target faction has claimed the chunks to the north, east, south and west of this chunk! It cannot be conquered!");
+                                                return;
+                                            }
+
+                                            // CONQUERABLE
+
                                             // remove locks on this chunk
                                             Iterator<LockedBlock> itr = main.lockedBlocks.iterator();
                                             while (itr.hasNext()) {

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -1175,9 +1175,9 @@ public class UtilitySubsystem {
     // this will return true if the chunks to the North, East, South and West of the target are claimed by the same faction as the target
     public boolean isClaimedChunkSurroundedByChunksClaimedBySameFaction(ClaimedChunk target) {
         ClaimedChunk northernClaimedChunk = getClaimedChunk(getChunkByDirection(target.getChunk(), "north"));
-        ClaimedChunk easternClaimedChunk = getClaimedChunk(getChunkByDirection(target.getChunk(), "east");
-        ClaimedChunk southernClaimedChunk = getClaimedChunk(getChunkByDirection(target.getChunk(), "south");
-        ClaimedChunk westernClaimedChunk = getClaimedChunk(getChunkByDirection(target.getChunk(), "west");
+        ClaimedChunk easternClaimedChunk = getClaimedChunk(getChunkByDirection(target.getChunk(), "east"));
+        ClaimedChunk southernClaimedChunk = getClaimedChunk(getChunkByDirection(target.getChunk(), "south"));
+        ClaimedChunk westernClaimedChunk = getClaimedChunk(getChunkByDirection(target.getChunk(), "west"));
 
         if (northernClaimedChunk == null ||
             easternClaimedChunk == null ||

--- a/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/factionsystem/Subsystems/UtilitySubsystem.java
@@ -85,9 +85,11 @@ public class UtilitySubsystem {
                                         // is at war with target faction
                                         if (faction.isEnemy(targetFaction.getName())) {
 
-                                            if (isClaimedChunkSurroundedByChunksClaimedBySameFaction(chunk)) {
-                                                player.sendMessage(ChatColor.RED + "Target faction has claimed the chunks to the north, east, south and west of this chunk! It cannot be conquered!");
-                                                return;
+                                            if (main.getConfig().getBoolean("surroundedChunksProtected")) {
+                                                if (isClaimedChunkSurroundedByChunksClaimedBySameFaction(chunk)) {
+                                                    player.sendMessage(ChatColor.RED + "Target faction has claimed the chunks to the north, east, south and west of this chunk! It cannot be conquered!");
+                                                    return;
+                                                }
                                             }
 
                                             // CONQUERABLE


### PR DESCRIPTION
Third time's the charm! I'm putting this pull request up before I test the code, so be aware that this needs to be tested.

I abstracted out all of the functionality into a isClaimedChunkSurroundedByChunksClaimedBySameFaction() method, which is located in the Utility Subsystem and uses other utility methods I created in order to accomplish this task.

There is single if-check added to the addChunkAtPlayerLocation() method. I am hoping it works.